### PR TITLE
fix mkdir in package.json

### DIFF
--- a/packages/core/base/package.json
+++ b/packages/core/base/package.json
@@ -21,7 +21,7 @@
     },
     "scripts": {
         "clean": "shx mkdir -p lib && shx rm -rf lib",
-        "package": "shx mkdir -p lib/cjs && shx mkdir -p lib/esm && echo '{\"type\":\"commonjs\"}' | npx json > ./lib/cjs/package.json && echo '{\"type\":\"module\"} ' | npx json > ./lib/esm/package.json",
+        "package": "shx mkdir -p lib/cjs lib/esm && echo '{\"type\":\"commonjs\"}' | npx json > ./lib/cjs/package.json && echo '{\"type\":\"module\"} ' | npx json > ./lib/esm/package.json",
         "prebuild": "pnpm run clean && pnpm run package"
     },
     "devDependencies": {

--- a/packages/core/base/package.json
+++ b/packages/core/base/package.json
@@ -21,7 +21,7 @@
     },
     "scripts": {
         "clean": "shx mkdir -p lib && shx rm -rf lib",
-        "package": "shx mkdir -p lib/{cjs,esm} && echo '{\"type\":\"commonjs\"}' | npx json > ./lib/cjs/package.json && echo '{\"type\":\"module\"} ' | npx json > ./lib/esm/package.json",
+        "package": "shx mkdir -p lib/cjs && shx mkdir -p lib/esm && echo '{\"type\":\"commonjs\"}' | npx json > ./lib/cjs/package.json && echo '{\"type\":\"module\"} ' | npx json > ./lib/esm/package.json",
         "prebuild": "pnpm run clean && pnpm run package"
     },
     "devDependencies": {

--- a/packages/ui/react/package.json
+++ b/packages/ui/react/package.json
@@ -21,7 +21,7 @@
     },
     "scripts": {
         "clean": "shx mkdir -p lib && shx rm -rf lib",
-        "package": "shx mkdir -p lib/cjs && shx mkdir -p lib/esm && echo '{\"type\":\"commonjs\"}' | npx json > ./lib/cjs/package.json && echo '{\"type\":\"module\"} ' | npx json > ./lib/esm/package.json",
+        "package": "shx mkdir -p lib/cjs lib/esm && echo '{\"type\":\"commonjs\"}' | npx json > ./lib/cjs/package.json && echo '{\"type\":\"module\"} ' | npx json > ./lib/esm/package.json",
         "prebuild": "pnpm run clean && pnpm run package"
     },
     "dependencies": {

--- a/packages/ui/react/package.json
+++ b/packages/ui/react/package.json
@@ -21,7 +21,7 @@
     },
     "scripts": {
         "clean": "shx mkdir -p lib && shx rm -rf lib",
-        "package": "shx mkdir -p lib/{cjs,esm} && echo '{\"type\":\"commonjs\"}' | npx json > ./lib/cjs/package.json && echo '{\"type\":\"module\"} ' | npx json > ./lib/esm/package.json",
+        "package": "shx mkdir -p lib/cjs && shx mkdir -p lib/esm && echo '{\"type\":\"commonjs\"}' | npx json > ./lib/cjs/package.json && echo '{\"type\":\"module\"} ' | npx json > ./lib/esm/package.json",
         "prebuild": "pnpm run clean && pnpm run package"
     },
     "dependencies": {


### PR DESCRIPTION
**Issue**
The package does not build as expected using Ubuntu 22.04 - the command `shx mkdir -p lib/{cjs,esm}` in package.json creates one folder lib/{cjs,esm} rather than two folders as expected (see image). This issue is consistent across npm, pnpm, and yarn. 

![mkdir-issue](https://user-images.githubusercontent.com/79712764/182870159-4edc6195-24c1-462f-a616-f64d3803b520.png)

**Fix**
Extended the script to specify two unique paths.   
